### PR TITLE
Fixed the spelling of "Merriam"

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ algorithms. In this course, students will:
 When? MWF 15:10-16:00
 Where? Roberts 218 
 
-Note: if necessary (e.g., if the instructor must quarantine or self-isolte),
+Note: if necessary (e.g., if the instructor must quarantine or self-isolate),
 class will be held via Zoom. If so, a link will be sent via email and via the
 class discussion board.
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ responsible for the honest completion and representation of their work, the
 appropriate citation of sources and the respect and recognition of others'
 academic endeavors.
 
-Plagiarism will not be tolerated in this course. According to the Meriam-Webster
+Plagiarism will not be tolerated in this course. According to the Merriam-Webster
 dictionary, plagiarism is `the act of using another person's words or ideas
 without giving credit to that person.'  Proper credit means describing all
 outside resources (conversations, websites, etc.), and explaining the extent to

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ hear or smell you.
 ### Course Textbook
 
 * (Required) [Algorithms by Jeff Erickson](https://jeffe.cs.illinois.edu/teaching/algorithms/)
-* (Suggested) Introduction to Algorithms, Third Edition} by Cormen, Leiserson, Rivest, and
+* (Suggested) Introduction to Algorithms, Third Edition by Cormen, Leiserson, Rivest, and
   Stein (CLRS). 
 
 ## Schedule


### PR DESCRIPTION
it is the [Merriam-Webster](https://www.google.com/search?gs_ssp=eJzj4tTP1TcwzMlJzlVgNGB0YPDiz00tKspMzFUoT00qLkktAgCR7Qnc&q=merriam+webster&oq=meriam+web&aqs=chrome.1.69i57j46i10i199i465j0i10i131i433l2j0i10j0i10i433j0i10l3.3584j0j7&sourceid=chrome&ie=UTF-8) Dictionary, not "Meriam Webster"