### PR TITLE
Style

### DIFF
--- a/hw/01G/Makefile
+++ b/hw/01G/Makefile
@@ -15,4 +15,4 @@ pdf:
 	${LATEX} -pdf
 
 pdf-watcher:
-	${LATEX} -pvc -pdf
+	${LATEX} -interaction=nonstopmode -pvc -pdf

--- a/hw/fasy-hw.sty
+++ b/hw/fasy-hw.sty
@@ -11,7 +11,7 @@
 
 \usepackage{enumerate}
 \usepackage{url}
-\usepackage{amsmath,amsfonts}
+\usepackage{amssymb, amsmath, amsfonts}
 \usepackage{xcolor}
 
 % ... for formatting algorithms


### PR DESCRIPTION
Currently, make pdf-watcher will stop when it encounters errors until it is given input. By adding this option to pdf-watcher, it will compile without any interaction. regular make still functions the same and halts on errors
```
-interaction=nonstopmode
```

adding "amssymb" to the packages allows the use of \therefore in homework, which is fun and nifty