### PR TITLE
Fixed grammar

### DIFF
--- a/handouts/recursion/recursion-invariants.tex
+++ b/handouts/recursion/recursion-invariants.tex
@@ -85,7 +85,7 @@ see~\cite[Ch.~1]{textbook}.
 
     \item INITIALIZTION This is like the base case for recursion.  Colloquially,
         we ask ``Why is this
-        true for the smallest input?'' (And, what is those inputs that
+        true for the smallest input?'' (And, what are those inputs that
         would allow us to return without a recursive call?)  More formally, we
         can say: If $n=n_0,A,B,C$ satisfy $P$, then after the call to
         $\textsc{Hanoi}(n_0,A,B,C)$, the recursion invariant $R$ is satisfied.


### PR DESCRIPTION
Changed "is" to "are" in reference to the plural "those"