### PR TITLE
"Monte Carol" to "Monte Carlo"

### DIFF
--- a/hw/07G/H-7G.tex
+++ b/hw/07G/H-7G.tex
@@ -62,7 +62,7 @@ might not always give the right answer; however, they either have a high
 probability of being correct or close to correct.
 
 \begin{enumerate}[(a)]
-    \item Give a Monte Carol algorithm to estimate~$\pi$.
+    \item Give a Monte Carlo algorithm to estimate~$\pi$.
     \item Let $n$ be the number of random numbers used by your algorithm.
         Explain why as $n \to \infty$, the expectation of the output for your
         algorithm is~$\pi$.


### PR DESCRIPTION
Typo, Monte Carol -> Monte Carlo